### PR TITLE
Initial csv batch limiting functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ uploads
 node_modules
 .DS_Store
 npm-debug.log
+config/config.json

--- a/controllers/bims_controller.js
+++ b/controllers/bims_controller.js
@@ -33,27 +33,27 @@ module.exports = {
             stream.destroy();
         }
 
-        let runConstructor = (r) => {
-            // console.log(stream.read());
-            while(batch.length < 1000){
-                let tempRow = new Row(...r);
+        let runConstructor = (readableStream) => {
+            while(batch.length < num){
+                let tempRow = new Row(...readableStream);
                 batch.push(tempRow);
                 console.log(`***\nBatch Length: ${batch.length}`);
             }
-            if( batch.length > 999){
+            if( batch.length > (num-1) ){
                 // if(stream.read() == null) { console.log('stream.read() is null');}
                 console.log('End of while loop, starting address check and batch deletion');
                 stream.pause();
                 i++;
                 console.log(`batch count: ${i}`);
                 checkAddressList();
-                batch = [];
+                
             }
         }
 
         let checkAddressList = () => {
             console.log('inside master address check function');
-            stream.resume();
+            batch = [];
+            return stream.resume();
         }
 
         parser.on('readable', () => {


### PR DESCRIPTION
Parsing of csv into batches to allow for subsequent processing

Allows for data flow control, in case of stream interruption

Todo:
 - condition needed for when batching is done, but under the row minimum. something akin to parser.end() == true
 - deletion of temp csv file rows, as rows are inserted into batch array
 - If stream interruption, how to start back up and at where we left off