### PR TITLE
foreign key from address master added to BIMS insert and console log clean up

### DIFF
--- a/controllers/bims_controller.js
+++ b/controllers/bims_controller.js
@@ -6,7 +6,6 @@ import addressController from './address.js';
 module.exports = {
     readData: (app) => {
         let stream = fs.createReadStream("./temp-data/bims.csv");
-        let batchSize = 100;
         let rawBatch = [];
         let addressMasterBatch = [];
         let counter = 0;
@@ -145,38 +144,27 @@ module.exports = {
         
         // function checkAddress(rawBatch, addressMasterBatch, callback ) {
         function checkAddress(rawBatchObject, addressMasterBatchObject) {
-          
             pause2()
                 .then( () => {
                     counter++;
-                    console.log(`**********************\n  Object Counter: ${counter}\n***************************************************`);
-                   return addressController.createAddress7(addressMasterBatchObject, rawBatchObject);
+                    console.log(`**********************\nObject Counter: ${counter}\n***************************************************`);
+                    return addressController.createAddress7(addressMasterBatchObject, rawBatchObject);
                 })
                 .then( () => {
-                    rawBatch.shift();
-                    addressMasterBatch.shift();
+                    deleteObject();
                 })
                 .then( () => {
                     resume();
                 })
                 .catch( (error) => {
-                    console.log(error);
+                    console.error(error);
                 });
         }
 
         // Function to pause data stream from file
-        function pause(){
-            counter++;
-            console.log(`**********************\n  Object Counter: ${counter}\n***************************************************`);
-            stream.unpipe(csvStream)
-            return csvStream.pause();
-        }
-
         function pause2() {
-            console.log('$$ inside pause2 - outside promise $$');
             return new Promise(
                 (resolve, reject) => {
-                    console.log('** inside pause2 - inside PROMISE **');
                     stream.unpipe(csvStream)
                     resolve( csvStream.pause() );
                 }
@@ -184,7 +172,7 @@ module.exports = {
         }
 
         function deleteObject() {
-            console.log('inside deleteObject');
+            console.log('\ninside deleteObject\n');
             return new Promise(
                 (resolve, reject) => {
                     rawBatch.shift();


### PR DESCRIPTION
* in address.js:
   * Attached foreign key to new BIMS insert, from the findOrCreate of the Master Address
   * Cleaned up `console.logs`
* in bims_controller.js:
   * deleted pause() function in favor of pause2() function. Needed a `Promise`.
   * created deleteObject() function to remove first item in rawBatchObject. Needed a `Promise`.
   * cleaned up `console.logs`
* Notes:
   * Use of `spread` has been recommened for `findOrCreate` in sequelize. However, use of `.spread`, in createAddress7(), causes query duplication. Seems to break promise chain. Used `.then` to make it work.... Potential fix is Promise.join(), but further research into performance over `.then` is needed. 
   * In address.js, need to clean up file, by deleting functions not being used
   * in address.js, need to create Insert functions for each dataset (hims, bims, scep, etc...) _and_ integrate them into the createAddress7 function somehow. maybe pass a 3rd argument for file name?